### PR TITLE
Remove post test script that clears firebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "node index.js",
     "dev": "nodemon -r dotenv/config index.js",
     "lint": "eslint --ignore-path .gitignore .",
-    "posttest": "npm run reset:firebase",
     "test": "ava --timeout=1m --verbose",
     "test:coverage": "nyc npm run test",
     "test:check-coverage": "npm run test:coverage && nyc check-coverage --lines 80 --branches 80 --statements 80 --functions 80",


### PR DESCRIPTION
We have plans of having a better way of cleaning the database. We recently ran into a user deletion quota limit from firebase, so disabling this script makes sense.